### PR TITLE
Clean up some code bits, add some logic checking about tweet length

### DIFF
--- a/src/Console/Command/TweeterCommand.php
+++ b/src/Console/Command/TweeterCommand.php
@@ -160,9 +160,22 @@ class TweeterCommand extends Command
             'Good food, good friends, good conversation. #memtech lunch. 11:30 today at ' . $event['venue_name'] . '. ' . $url . PHP_EOL,
         ];
 
-        shuffle($tweets);
+        foreach ($tweets as $key => $tweet)
+        {
+            if (strlen($tweet) > 140)
+            {
+                unset($tweets[$key]);
+            }
+        }
 
-        return $tweets[0];
+        if (count($tweets) > 0)
+        {
+            shuffle($tweets);
+
+            return $tweets[0];
+        }
+
+        exit('All tweets were too long to tweet');
     }
 
     /**
@@ -173,15 +186,19 @@ class TweeterCommand extends Command
     protected function shortenUrl($url)
     {
         $google_key = getenv('GOOGLE_SHORTEN_KEY');
+
         $link = new Link;
         $link->setLongUrl('http://mremi/url-shortener');
-        $googleProvider = new GoogleProvider(
-            $google_key,
-            array('connect_timeout' => 1, 'timeout' => 1)
-        );
 
+        $options =  [
+            'connect_timeout' => 1,
+            'timeout' => 1,
+        ];
+
+        $googleProvider = new GoogleProvider($google_key, $options);
         $googleProvider->shorten($link);
         $shortUrl = $link->getShortUrl();
+
         return $shortUrl;
     }
 }

--- a/src/Console/Command/TweeterCommand.php
+++ b/src/Console/Command/TweeterCommand.php
@@ -93,14 +93,9 @@ class TweeterCommand extends Command
     */
     protected function twitterConnect()
     {
-        $twitter_key = getenv('TWITTER_KEY');
-        $twitter_secret = getenv('TWITTER_SECRET');
-        $twitter_token = getenv('TWITTER_TOKEN');
-        $twitter_token_secret = getenv('TWITTER_TOKEN_SECRET');
-
-        Codebird::setConsumerKey($twitter_key, $twitter_secret);
+        Codebird::setConsumerKey(getenv('TWITTER_KEY'), getenv('TWITTER_SECRET'));
         $cb = Codebird::getInstance();
-        $cb->setToken($twitter_token, $twitter_token_secret);
+        $cb->setToken(getenv('TWITTER_TOKEN'), getenv('TWITTER_TOKEN_SECRET'));
         
         return $cb;
     }

--- a/src/Console/Command/TweeterCommand.php
+++ b/src/Console/Command/TweeterCommand.php
@@ -185,8 +185,6 @@ class TweeterCommand extends Command
      */
     protected function shortenUrl($url)
     {
-        $google_key = getenv('GOOGLE_SHORTEN_KEY');
-
         $link = new Link;
         $link->setLongUrl('http://mremi/url-shortener');
 
@@ -195,7 +193,7 @@ class TweeterCommand extends Command
             'timeout' => 1,
         ];
 
-        $googleProvider = new GoogleProvider($google_key, $options);
+        $googleProvider = new GoogleProvider(getenv('GOOGLE_SHORTEN_KEY'), $options);
         $googleProvider->shorten($link);
         $shortUrl = $link->getShortUrl();
 

--- a/src/Console/Command/TweeterCommand.php
+++ b/src/Console/Command/TweeterCommand.php
@@ -97,9 +97,10 @@ class TweeterCommand extends Command
         $twitter_secret = getenv('TWITTER_SECRET');
         $twitter_token = getenv('TWITTER_TOKEN');
         $twitter_token_secret = getenv('TWITTER_TOKEN_SECRET');
+
         Codebird::setConsumerKey($twitter_key, $twitter_secret);
         $cb = Codebird::getInstance();
-        $cb->setToken('TWITTER_TOKEN','TWITTER_TOKEN_SECRET');
+        $cb->setToken($twitter_token, $twitter_token_secret);
         
         return $cb;
     }

--- a/tweeter.php
+++ b/tweeter.php
@@ -6,10 +6,24 @@ require __DIR__.'/vendor/autoload.php';
 use Memtech\Console\Command\TweeterCommand;
 use Symfony\Component\Console\Application;
 
-// Set up the environment variables
-$dotenv = new Dotenv\Dotenv(__DIR__);
-$dotenv->load();
-$dotenv->required(['TWITTER_KEY','TWITTER_SECRET','TWITTER_TOKEN','TWITTER_TOKEN_SECRET','MEETUP_KEY','GOOGLE_SHORTEN_KEY']);
+try
+{
+    // Set up the environment variables
+    $dotenv = new Dotenv\Dotenv(__DIR__);
+    $dotenv->load();
+    $dotenv->required([
+        'TWITTER_KEY',
+        'TWITTER_SECRET',
+        'TWITTER_TOKEN',
+        'TWITTER_TOKEN_SECRET',
+        'MEETUP_KEY',
+        'GOOGLE_SHORTEN_KEY'
+    ]);
+}
+catch (\Dotenv\Exception\ValidationException $e)
+{
+    exit($e->getMessage());
+}
 
 $application = new Application();
 $application->add(new TweeterCommand());

--- a/tweeter.php
+++ b/tweeter.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+date_default_timezone_set('America/Chicago');
 
 require __DIR__.'/vendor/autoload.php';
 


### PR DESCRIPTION
- Clean up shorten URL code, Add length check to tweets so we never tweet a tweet that shouldn't be tweeted
- Tell PHP what timezone we're in so it doesn't puke out a big warning
- gracefully catch if the user is missing ENV variables
- since we never re-use the variables we set, just pass the getenv() calls into the functions we're passing the variables to
- fix sending strings to setToken() and send actual values
